### PR TITLE
Use actions/upload-artifact@v4 in GHA workflow

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -24,11 +24,10 @@ jobs:
         run: ./pleasew test --log_file plz-out/log/test.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: logs
-          path: |
-            plz-out/log
+          name: logs-${{ matrix.python-version }}
+          path: plz-out/log
   release:
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
actions/upload-artifact@v2 is deprecated and workflows aren't able to use it any more. v4 requires uploaded artifacts to have unique names, so ensure each job in the matrix uploads an artifact with a different name.