### PR TITLE
Run tests against Python 3.9 - 3.13 in GHA workflow

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -6,11 +6,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: '3.7'
-          - python-version: '3.8'
-          - python-version: '3.9'
-          - python-version: '3.10'
-          - python-version: '3.11'
+          python-version:
+            - '3.9'
+            - '3.10'
+            - '3.11'
+            - '3.12'
+            - '3.13'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,3 +1,6 @@
+[Please]
+Version = >=17.10.3
+
 [Plugin "python"]
 Target = //plugins:python
 

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,6 +1,6 @@
 plugin_repo(
   name = "python",
-  revision = "v1.3.0",
+  revision = "v1.7.4",
 )
 
 plugin_repo(


### PR DESCRIPTION
These are the versions of Python supported by python-rules. Also bump the python-rules plugin to the latest version (it has better support for Python >= 3.12) and add a minimum Please version (the same as the one for python-rules).